### PR TITLE
Add find_config to train

### DIFF
--- a/cxflow/cli/train.py
+++ b/cxflow/cli/train.py
@@ -1,26 +1,25 @@
 import logging
-import os.path as path
 
 from typing import Iterable
 
-from .util import fallback, validate_config
+from .util import fallback, validate_config, find_config
 from .common import run
 from ..utils.config import load_config
 
 
-def train(config_file: str, cl_arguments: Iterable[str], output_root: str) -> None:
+def train(config_path: str, cl_arguments: Iterable[str], output_root: str) -> None:
     """
     Load config and start the training.
 
-    :param config_file: path to configuration file
+    :param config_path: path to configuration file
     :param cl_arguments: additional command line arguments which will update the configuration
     :param output_root: output root in which the training directory will be created
     """
     config = None
 
     try:
-        assert path.exists(config_file), '`{}` does not exist'.format(config_file)
-        config = load_config(config_file=config_file, additional_args=cl_arguments)
+        config_path = find_config(config_path)
+        config = load_config(config_file=config_path, additional_args=cl_arguments)
         validate_config(config)
         logging.debug('\tLoaded config: %s', config)
     except Exception as ex:  # pylint: disable=broad-except

--- a/cxflow/entry_point.py
+++ b/cxflow/entry_point.py
@@ -47,7 +47,7 @@ def entry_point() -> None:
     logger.addHandler(stderr_handler)
 
     if known_args.subcommand == 'train':
-        train(config_file=known_args.config_file, cl_arguments=unknown_args, output_root=known_args.output_root)
+        train(config_path=known_args.config_file, cl_arguments=unknown_args, output_root=known_args.output_root)
 
     elif known_args.subcommand == 'resume':
         resume(config_path=known_args.config_path, restore_from=known_args.restore_from, cl_arguments=unknown_args,


### PR DESCRIPTION
At the moment both `predict` and `resume` can derive the config path from a dir. Adding the same functionality to `train` would allow some simplification, e.g.:
```
cxflow train mnist
```
instead of 
```
cxflow train mnist/config.yaml
```

in our examples.