### PR TITLE
Create log dirs with correct permissions, Shorten log dir names

### DIFF
--- a/cxflow/cli/common.py
+++ b/cxflow/cli/common.py
@@ -18,7 +18,7 @@ from ..utils.training_trace import TrainingTrace, TrainingTraceKeys
 from ..main_loop import MainLoop
 
 
-def create_output_dir(config: dict, output_root: str, default_model_name: str='NonameModel') -> str:
+def create_output_dir(config: dict, output_root: str, default_model_name: str='Unnamed') -> str:
     """
     Create output_dir under the given ``output_root`` and
         - dump the given config to YAML file under this dir
@@ -42,9 +42,9 @@ def create_output_dir(config: dict, output_root: str, default_model_name: str='N
         logging.info('\tOutput root folder "%s" does not exist and will be created', output_root)
         os.makedirs(output_root)
 
-    output_dir = tempfile.mkdtemp(prefix='{}_{}_{}_'.format(model_name, datetime.now().strftime('%Y-%m-%d-%H-%M-%S'),
-                                                            get_random_name()),
-                                  dir=output_root)
+    output_dir = path.join(output_root, '{}_{}_{}'.format(datetime.now().strftime('%Y-%m-%d-%H-%M-%S'),
+                                                          model_name, get_random_name()))
+    os.makedirs(output_dir)
     logging.info('\tOutput dir: %s', output_dir)
 
     # create file logger

--- a/cxflow/cli/common.py
+++ b/cxflow/cli/common.py
@@ -1,6 +1,6 @@
 import os
+import errno
 import logging
-import tempfile
 import os.path as path
 from datetime import datetime
 
@@ -42,9 +42,17 @@ def create_output_dir(config: dict, output_root: str, default_model_name: str='U
         logging.info('\tOutput root folder "%s" does not exist and will be created', output_root)
         os.makedirs(output_root)
 
-    output_dir = path.join(output_root, '{}_{}_{}'.format(datetime.now().strftime('%Y-%m-%d-%H-%M-%S'),
-                                                          model_name, get_random_name()))
-    os.makedirs(output_dir)
+    # keep trying to create new output dir until it succeeds
+    # this is neccessary due to improbable yet possible output dir name conflicts
+    while True:
+        try:
+            output_dir = path.join(output_root, '{}_{}_{}'.format(datetime.now().strftime('%Y-%m-%d-%H-%M-%S'),
+                                                                  model_name, get_random_name()))
+            os.mkdir(output_dir)
+            break
+        except OSError as ex:
+            if ex.errno != errno.EEXIST:
+                raise ex
     logging.info('\tOutput dir: %s', output_dir)
 
     # create file logger


### PR DESCRIPTION
Although small, this PR might be controversial.

Changes:
- create log dir with `os.makedirs` instead of `tempfile.mkdtemp` which sets dir permissions to `700`
- use new log dir name pattern `[DATE-TIME]_[MODEL-NAME]_[DOCKER_LIKE_RANDOM]`

(the original was `[MODEL-NAME]_[DATE-TIME]_[DOCKER_LIKE_RANDOM]_[RANDOM]`)

Thinking behind:
- moving datetime to the front is quite obvious, it allows intuitive chronological sorting
- docker like random rendered the tempfile random obsolete (I stopped using it entirely)
- new dir name is significantly shorter

FYI:
There are 14880 possible docker like random names. The chance of conflict (same model name, datetime and random) is therefore very low . Interestingly, with 140 names selected randomly there is roughly 50% chance of having a duplicity (birthday paradox). Perhaps we want to increase the number of names or introduce 3rd word (color?).

closes #170 