### PR TITLE
Allow logging nanmeans as well.

### DIFF
--- a/cxflow/hooks/write_csv.py
+++ b/cxflow/hooks/write_csv.py
@@ -119,8 +119,11 @@ class WriteCSV(AbstractHook):
                         logging.warning(err_message)
                     values.append(self._default_value)
                     continue
+
                 if isinstance(value, dict) and 'mean' in value:
                     value = value['mean']
+                elif isinstance(value, dict) and 'nanmean' in value:
+                    value = value['nanmean']
 
                 if np.isscalar(value):
                     values.append(value)

--- a/cxflow/tests/hooks/write_csv_test.py
+++ b/cxflow/tests/hooks/write_csv_test.py
@@ -25,7 +25,7 @@ def _get_epoch_data():
         ('test', collections.OrderedDict([
             ('accuracy', 2),
             ('precision', 2 * np.ones(_EXAMPLES)),
-            ('loss', collections.OrderedDict([('mean', 2)])),
+            ('loss', collections.OrderedDict([('nanmean', 2)])),
             ('omitted', 0)])),
         ('valid', collections.OrderedDict([
             ('accuracy', 3),


### PR DESCRIPTION
Since Cognexa/cxflow#150, it is impossible to write nanmeans to CSV training progress (only means are allowed).

This PR provides support for nanmeans as well which is crucial for many variables.