### PR TITLE
Add coverage reporting 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,14 @@ references:
       command: |
         apt-get update -qy
         apt-get install -y git python3-dev python3-pip curl
+        pip3 install coveralls coverage
 
   arch_deps: &arch_deps
     run:
       name: Install dependencies on Arch Linux.
       command: |
         pacman -S --noconfirm python python-pip git base-devel curl
+        pip install coveralls coverage
 
   install: &install
     run:
@@ -44,6 +46,14 @@ references:
       name: Generate documentation
       command: |
         bash <(curl -fsSL https://raw.githubusercontent.com/Cognexa/ci-utils/master/doc_deploy.sh)
+
+  coverage: &coverage
+    run:
+      name: Report test coverage
+      command: |
+        coverage run setup.py test
+        coverage report
+        coveralls
 
 jobs:
 
@@ -77,6 +87,13 @@ jobs:
       - *install
       - *test
 
+  report_coverage:
+    docker:
+      - image: pritunl/archlinux:2017-07-08
+    working_directory: ~/cxflow
+    steps:
+      - *coverage
+
   generate_documentation:
     docker:
       - image: ubuntu:rolling
@@ -105,6 +122,9 @@ workflows:
       - test_ubuntu_latest
       - test_ubuntu_rolling
       - test_archlinux
+      - report_coverage:
+          requires:
+            - test_archlinux
       - generate_documentation:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,12 +86,6 @@ jobs:
       - checkout
       - *install
       - *test
-
-  report_coverage:
-    docker:
-      - image: pritunl/archlinux:2017-07-08
-    working_directory: ~/cxflow
-    steps:
       - *coverage
 
   generate_documentation:
@@ -122,9 +116,6 @@ workflows:
       - test_ubuntu_latest
       - test_ubuntu_rolling
       - test_archlinux
-      - report_coverage:
-          requires:
-            - test_archlinux
       - generate_documentation:
           filters:
             branches:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # cxflow
 [![CircleCI](https://circleci.com/gh/Cognexa/cxflow/tree/master.svg?style=shield)](https://circleci.com/gh/Cognexa/cxflow/tree/master)
 [![PyPI version](https://badge.fury.io/py/cxflow.svg)](https://badge.fury.io/py/cxflow)
+[![Coverage 
+Status](https://coveralls.io/repos/github/Cognexa/cxflow/badge.svg?branch=master)](https://coveralls.io/github/Cognexa/cxflow?branch=master)
 [![Development Status](https://img.shields.io/badge/status-CX%20Regular-brightgreen.svg?style=flat)]()
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![Master Developer](https://img.shields.io/badge/master-Petr%20Bělohlávek-lightgrey.svg?style=flat)]()
@@ -37,6 +39,3 @@ At the moment we support the following extensions:
 
 All contributions are welcomed. Please read our [contributor's guide](CONTRIBUTING.md).
 
-## License
-
-[MIT](LICENSE)


### PR DESCRIPTION
`coverage` and `coveralls` python packages are installed in Ubuntu images as well although it is not required at the moment (forward compatibility)