### PR TITLE
Modify LogProfile to not fail on empty streams

### DIFF
--- a/cxflow/hooks/log_profile.py
+++ b/cxflow/hooks/log_profile.py
@@ -39,14 +39,14 @@ class LogProfile(AbstractHook):
 
         read_data_total = 0
         eval_total = 0
-        train_total = sum(profile['eval_batch_train'])
-        hooks_total = sum(profile['after_epoch_hooks'])
+        train_total = sum(profile.get('eval_batch_train', []))
+        hooks_total = sum(profile.get('after_epoch_hooks', []))
 
         for stream_name in chain(extra_streams, ['train']):
-            read_data_total += sum(profile['read_batch_' + stream_name])
-            hooks_total += sum(profile['after_batch_hooks_' + stream_name])
+            read_data_total += sum(profile.get('read_batch_' + stream_name, []))
+            hooks_total += sum(profile.get('after_batch_hooks_' + stream_name, []))
             if stream_name != 'train':
-                eval_total += sum(profile['eval_batch_' + stream_name])
+                eval_total += sum(profile.get('eval_batch_' + stream_name, []))
 
         logging.info('\tT read data:\t%f', read_data_total)
         logging.info('\tT train:\t%f', train_total)

--- a/cxflow/tests/hooks/log_profile_test.py
+++ b/cxflow/tests/hooks/log_profile_test.py
@@ -44,8 +44,24 @@ class LogProfileTest(CXTestCase):
 
     def test_missing_train(self):
         """Test KeyError raised on missing profile entries."""
-        self.assertRaises(KeyError, self._hook.after_epoch_profile, 0, {}, [])
-        self.assertRaises(KeyError, self._hook.after_epoch_profile, 0, {'some_contents': 1}, [])
+        with LogCapture() as log_capture:
+            self._hook.after_epoch_profile(0, {}, [])
+
+        log_capture.check(
+            ('root', 'INFO', '\tT read data:\t0.000000'),
+            ('root', 'INFO', '\tT train:\t0.000000'),
+            ('root', 'INFO', '\tT eval:\t0.000000'),
+            ('root', 'INFO', '\tT hooks:\t0.000000')
+        )
+        with LogCapture() as log_capture:
+            self._hook.after_epoch_profile(0, {'some_contents': 1}, [])
+
+        log_capture.check(
+            ('root', 'INFO', '\tT read data:\t0.000000'),
+            ('root', 'INFO', '\tT train:\t0.000000'),
+            ('root', 'INFO', '\tT eval:\t0.000000'),
+            ('root', 'INFO', '\tT hooks:\t0.000000')
+        )
 
     def test_train_only(self):
         """Test profile handling with only train stream."""
@@ -61,7 +77,15 @@ class LogProfileTest(CXTestCase):
 
     def test_extra_streams(self):
         """Test extra streams handling."""
-        self.assertRaises(KeyError, self._hook.after_epoch_profile, 0, _TRAIN_ONLY_PROFILE, ['valid'])
+        with LogCapture() as log_capture:
+            self._hook.after_epoch_profile(0, _TRAIN_ONLY_PROFILE, ['valid'])
+
+        log_capture.check(
+            ('root', 'INFO', '\tT read data:\t6.120000'),
+            ('root', 'INFO', '\tT train:\t21.900000'),
+            ('root', 'INFO', '\tT eval:\t0.000000'),
+            ('root', 'INFO', '\tT hooks:\t9.800000'),
+        )
 
         # test additional entries being ignored if the extra stream was not specified
         with LogCapture() as log_capture:


### PR DESCRIPTION
This is solution proposal to [Issue 187](https://github.com/Cognexa/cxflow/issues/187). Main loop should handle emptiness of batches/streams and this hook should not fail. Alternative is leaving the possibility of failing with main loop still doing checking.