### PR TITLE
Add temporary fix for YAML ordereddict

### DIFF
--- a/cxflow/cli/common.py
+++ b/cxflow/cli/common.py
@@ -181,6 +181,7 @@ def create_hooks(config: dict, model: AbstractModel,
             if hook_params is None:
                 logging.warning('\t\t Empty config of `%s` hook', hook_path)
                 hook_params = {}
+            hook_params = dict(hook_params.items())
 
             hook_module, hook_class = parse_fully_qualified_name(hook_path)
             # find the hook module if not specified

--- a/cxflow/cli/common.py
+++ b/cxflow/cli/common.py
@@ -110,6 +110,10 @@ def create_model(config: dict, output_dir: Optional[str], dataset: AbstractDatas
     logging.info('Creating a model')
 
     model_config = config['model']
+
+    # workaround for ruamel.yaml expansion bug; see #222
+    model_config = dict(model_config.items())
+
     assert 'class' in model_config, '`model.class` not present in the config'
     model_module, model_class = parse_fully_qualified_name(model_config['class'])
 
@@ -181,6 +185,8 @@ def create_hooks(config: dict, model: AbstractModel,
             if hook_params is None:
                 logging.warning('\t\t Empty config of `%s` hook', hook_path)
                 hook_params = {}
+
+            # workaround for ruamel.yaml expansion bug; see #222
             hook_params = dict(hook_params.items())
 
             hook_module, hook_class = parse_fully_qualified_name(hook_path)


### PR DESCRIPTION
Sometimes when expanding ruamel's `ordereddict` via `**` or directly converting it to `dict`, some values just get lost. This PR is a temporary fix, but the issue should be reported upstream.

Minimal working example to reproduce `ruamel`'s bug:
```python
#!/usr/bin/env python3
import ruamel.yaml

code = """\
anchored: &anchor
  a : 1

mapping:
  <<: *anchor
  b: 2
"""

mapping = ruamel.yaml.load(code, ruamel.yaml.RoundTripLoader)['mapping']

print(mapping)
print({**mapping})
print(dict(mapping))
print(dict(mapping.items()))
```

Output:
```
ordereddict([('b', 2), ('a', 1)])
{'b': 2}
{'b': 2}
{'b': 2, 'a': 1}
```